### PR TITLE
Dont specify syn patch version

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 proc-macro2 = "1.0.95"
 quote = "1.0.40"
-syn = "2.0.104"
+syn = "2"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To avoid conflicts where rtic specifies a version older than 2.0.104